### PR TITLE
Pierwsze modyfikacje pofaktowe interfejsu JG

### DIFF
--- a/gamestate.h
+++ b/gamestate.h
@@ -103,7 +103,8 @@ public:
         mysz_pop_y = GetMouseY();
         kurosr_czulosc = 0;
         srand(time(NULL));
-        epizod_doc = 1; //AG usunalem losowanie bo nie ma sensu losować poziomu trudnosci, niech bedzie lvl 1 diff na poczatku
+        epizod_doc = (char)(rand() % 4 + 1);//JG:losuje epizod pod tlo po uruchomieniu, dotyczy szaty graficznej, poziomy z dalszych epizodow beda zablokowane w wyborze poziomow
+        //epizod_doc = 1; //AG usunalem losowanie bo nie ma sensu losować poziomu trudnosci, niech bedzie lvl 1 diff na poczatku
         epizod = 0;
         poziom = 1;
         poziom_doc = 1;

--- a/przycisk.cpp
+++ b/przycisk.cpp
@@ -20,18 +20,30 @@ void PrzyciskTekst::draw() const {
 #define SCALING (1.f)
 
 void PrzyciskTekst::drawInactive(int x, int y) const {
+	Rectangle pom = getBoundingRect();//JG mod MG0
 	if (!(flags & BUTTON_NO_OUTLINE)) {
-		DrawRectangleLinesEx(getBoundingRect(), 2.5f, EpisodeTheme.borderColor);
-		DrawRectangleRec(getBoundingRect(), Fade(EpisodeTheme.bgColor, 0.65f));
+		DrawRectangleRec({pom.x - 2.5f *SCALING, pom.y - 2.5f * SCALING, pom.width + 5.0f *SCALING, pom.height + 5.0f * SCALING}, EpisodeTheme.textColor);//JG mod MG0
+		DrawTexturePro(grafiki->pole1.text, {los_pole_x, los_pole_y, grafiki->pole1.szer * 0.5f, grafiki->pole1.wys * 0.5f }, pom, { 0.0f, 0.0f }, 0.0f, ColorBrightness(WHITE, 0.0f));//JG+
+		/*DrawRectangleLinesEx(getBoundingRect(), 2.5f, EpisodeTheme.borderColor);
+		DrawRectangleRec(getBoundingRect(), Fade(EpisodeTheme.bgColor, 0.65f));*/
 	}
 	DrawTextEx(EpisodeTheme.textFont, text, {(float)x, (float)y}, getFontSizeScaled(), SCALING, EpisodeTheme.textColor);
 }
 void PrzyciskTekst::drawHover(int x, int y) const {
-	DrawRectangleRec(getBoundingRect(), ColorBrightness(EpisodeTheme.bgColor, 0.35f));
-	DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, Fade(EpisodeTheme.textColor, 0.3f));
+	//DrawRectangleRec(getBoundingRect(), ColorBrightness(EpisodeTheme.bgColor, 0.35f));
+	Rectangle pom = getBoundingRect();//JG mod MG0
+	DrawRectangleRec({ pom.x - 2.5f * SCALING, pom.y - 2.5f * SCALING, pom.width + 5.0f * SCALING, pom.height + 5.0f * SCALING }, EpisodeTheme.textColor);//JG mod MG0
+	DrawTexturePro(grafiki->pole1.text, { los_pole_x, los_pole_y, grafiki->pole1.szer * 0.5f, grafiki->pole1.wys * 0.5f }, pom, { 0.0f, 0.0f }, 0.0f, ColorBrightness(WHITE, -0.5f));//JG+
+	DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, EpisodeTheme.textColor);//JG mod MG0
+	//DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, Fade(EpisodeTheme.textColor, 0.3f));
 }
 void PrzyciskTekst::drawActive(int x, int y) const {
-	drawHover(x, y);
+	//drawHover(x, y);
+	Rectangle pom = getBoundingRect();//JG mod MG0
+	DrawRectangleRec({ pom.x - 2.5f * SCALING, pom.y - 2.5f * SCALING, pom.width + 5.0f * SCALING, pom.height + 5.0f * SCALING }, EpisodeTheme.textColor);//JG mod MG0
+	DrawTexturePro(grafiki->pole1.text, { los_pole_x, los_pole_y, grafiki->pole1.szer * 0.5f, grafiki->pole1.wys * 0.5f }, pom, { 0.0f, 0.0f }, 0.0f, ColorBrightness(WHITE, -0.75f));//JG+
+	DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, EpisodeTheme.textColor);//JG mod MG0
+	//DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, Fade(EpisodeTheme.textColor, 0.3f));
 }
 
 void PrzyciskTekst::update() {
@@ -76,11 +88,21 @@ void PrzyciskTekst::getDrawCoords(int* x, int* y) const {
 }
 
 void RadioPrzyciskTekst::drawActive(int x, int y) const {
-	DrawRectangleRec(getBoundingRect(), ColorBrightness(EpisodeTheme.bgColor, -0.35f));
-	DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, Fade(EpisodeTheme.textColor, 0.3f));
+	//DrawRectangleRec(getBoundingRect(), ColorBrightness(EpisodeTheme.bgColor, -0.35f));
+	//DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, Fade(EpisodeTheme.textColor, 0.3f));
+	Rectangle pom = getBoundingRect();//JG mod MG0
+	DrawRectangleRec({ pom.x - 2.5f * SCALING, pom.y - 2.5f * SCALING, pom.width + 5.0f * SCALING, pom.height + 5.0f * SCALING }, EpisodeTheme.textColor);//JG mod MG0
+	DrawTexturePro(grafiki->pole1.text, { los_pole_x, los_pole_y, grafiki->pole1.szer * 0.5f, grafiki->pole1.wys * 0.5f }, pom, { 0.0f, 0.0f }, 0.0f, ColorBrightness(WHITE, -0.75f));//JG+
+	DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, EpisodeTheme.textColor);//JG mod MG0
+	//DrawTextEx(EpisodeTheme.textFont, text, { (float)x, (float)y }, getFontSizeScaled(), SCALING, Fade(EpisodeTheme.textColor, 0.3f));
 }
-void RadioPrzyciskTekst::handleStateChangeConditions()  {
+//void RadioPrzyciskTekst::handleStateChangeConditions()  {//MG0
+//	PrzyciskTekst::handleStateChangeConditions();
+//	if (activeCondition() && state != NAJECHANY)
+//		state = AKTYWNY;
+//}
+void RadioPrzyciskTekst::handleStateChangeConditions() {
 	PrzyciskTekst::handleStateChangeConditions();
-	if (activeCondition() && state != NAJECHANY)
+	if (activeCondition())//JG mod MG0
 		state = AKTYWNY;
 }

--- a/przycisk.h
+++ b/przycisk.h
@@ -16,6 +16,12 @@ enum StanPrzycisku {
 #define BUTTON_NO_OUTLINE (1<<1) // Czy nie rysować go w prostokącie?
 
 struct _Przycisk {
+
+	//JG+:do losowej tekstury:
+	float los_pole_x;
+	float los_pole_y;
+	//JG+:koniec
+
 	ScreenPos pozycja; // pozycja przycisku na ekranie
 	ScreenPos rozmiar; // rozmiar przycisku na ekranie
 	StanPrzycisku state; // stan przycisku
@@ -38,6 +44,9 @@ struct _Przycisk {
 		onActivation = FunkcjaAktywacji;
 		flags = Flagi;
 		state = NIEAKTYWNY;
+
+		los_pole_x = (float)(rand() % 51) * 0.01f * 1000.0f;//JG+
+		los_pole_y = (float)(rand() % 51) * 0.01f * 1000.0f;//JG+
 	}
 	_Przycisk() {
 		pozycja = { 0,0,0,0 };
@@ -45,6 +54,9 @@ struct _Przycisk {
 		onActivation = [&] {};
 		flags = BUTTON_DISABLED;
 		state = NIEAKTYWNY;
+
+		los_pole_x = (float)(rand() % 51) * 0.01f * 1000.0f;//JG+
+		los_pole_y = (float)(rand() % 51) * 0.01f * 1000.0f;//JG+
 	}
 
 	virtual void update() = 0; // Update, przed rysowaniem.


### PR DESCRIPTION
Pierwsze modyfikacje pofaktowe interfejsu - wypełnione teksturą przyciski, przywrócenie losowania tła po uruchomieniu, brak podświetlania wciśniętych przycisków, których opcja jest aktualnie wybrana (ujednolica to styl menu ze stylem rozgrywki). Inne obrysy przycisków. Docelowo pasowałoby aby przyciski miały rozmiar niezależny od napisu i były na przeźroczystych panelach. JG